### PR TITLE
add retry logic for updating hostfile with cURL and improved error handling

### DIFF
--- a/config_dashboard.php
+++ b/config_dashboard.php
@@ -68,7 +68,23 @@ PHP;
                 $command = '/usr/bin/cat files/M17Hosts.txt';
                 break;
             case 'updatehostfile':
-                $command = '/usr/bin/curl https://hostfiles.refcheck.radio/M17Hosts.txt -o files/M17Hosts.txt -A "rpi-dashboard Hostfile Updater"';
+                $url  = 'https://hostfiles.refcheck.radio/M17Hosts.txt';
+                $dest = __DIR__ . '/files/M17Hosts.txt';
+                [$ok, $msg, $status, $hdrs, $attempts] = update_hostfile_with_retries($url, $dest, 'rpi-dashboard Hostfile Updater');
+
+                $rateBits = [];
+                foreach (['x-ratelimit-limit','x-ratelimit-remaining','x-ratelimit-reset','retry-after'] as $h) {
+                    if (isset($hdrs[$h])) $rateBits[] = strtoupper($h) . ': ' . $hdrs[$h];
+                }
+                $meta = $rateBits ? ("\n" . implode("\n", $rateBits)) : '';
+                $commandOutput = sprintf(
+                    "%s\nHTTP status: %s\nAttempts: %d%s",
+                    $msg,
+                    $status ?: 'n/a',
+                    $attempts,
+                    $meta
+                );
+                $command = '';
                 break;
             case 'log':
                 $command = '/usr/bin/tail -n 30 '.htmlspecialchars($config['gateway_log_file']);

--- a/functions.php
+++ b/functions.php
@@ -40,6 +40,94 @@ if (!file_exists($configFile)) {
     }
 }
 
+// just PHP cURL it, yo.
+function update_hostfile_with_retries(
+    string $url,
+    string $destPath,
+    string $userAgent = 'rpi-dashboard Hostfile Updater',
+    int $maxRetries = 5,
+    int $timeout = 20,
+    int $connectTimeout = 10,
+    int $maxSleepCap = 30
+): array {
+    $attempt = 0;
+    $tmpPath = $destPath . '.tmp';
+
+    while ($attempt <= $maxRetries) {
+        $attempt++;
+
+        $headers = [];
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_USERAGENT      => $userAgent,
+            CURLOPT_CONNECTTIMEOUT => $connectTimeout,
+            CURLOPT_TIMEOUT        => $timeout,
+            CURLOPT_HEADERFUNCTION => function($ch, $header) use (&$headers) {
+                $len = strlen($header);
+                $parts = explode(':', $header, 2);
+                if (count($parts) === 2) {
+                    $headers[strtolower(trim($parts[0]))] = trim($parts[1]);
+                }
+                return $len;
+            },
+        ]);
+
+        $body   = curl_exec($ch);
+        $error  = curl_error($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($error) {
+            return [false, "cURL error: $error", $status ?: 0, $headers, $attempt];
+        }
+
+        if ($status === 200) {
+            if ($body === false || $body === '') {
+                return [false, "Empty response body from server.", $status, $headers, $attempt];
+            }
+            if (file_put_contents($tmpPath, $body) === false) {
+                return [false, "Failed writing temp file.", $status, $headers, $attempt];
+            }
+            if (!@rename($tmpPath, $destPath)) {
+                @unlink($tmpPath);
+                return [false, "Failed moving temp file into place.", $status, $headers, $attempt];
+            }
+            $bytes = strlen($body);
+            return [true, "Hostfile updated successfully ($bytes bytes).", $status, $headers, $attempt];
+        }
+
+        if ($status === 429) {
+            // Respect Retry-After
+            $retryAfter = 0;
+            if (isset($headers['retry-after'])) {
+                $ra = $headers['retry-after'];
+                if (ctype_digit($ra)) {
+                    $retryAfter = (int)$ra;
+                } else {
+                    $ts = strtotime($ra);
+                    if ($ts !== false) {
+                        $retryAfter = max(0, $ts - time());
+                    }
+                }
+            }
+            // Exponential backoff + jitter; cap so the UI doesn’t hang forever
+            $backoff = max($retryAfter, pow(2, $attempt)) + (random_int(0, 1000) / 1000.0);
+            $sleepFor = (int)ceil(min($backoff, $maxSleepCap));
+            if ($attempt > $maxRetries) {
+                return [false, "Rate limited (HTTP 429). Max retries exceeded.", $status, $headers, $attempt];
+            }
+            sleep($sleepFor);
+            continue;
+        }
+
+        return [false, "HTTP $status returned by server.", $status, $headers, $attempt];
+    }
+
+    return [false, "Unreachable code path hit, which is impressive.", 0, [], $attempt];
+}
+
 
 // just read the latest 50 lines from the logfile
 // while not touching the rest of the file


### PR DESCRIPTION
You’re curling a file from a button click and hoping the universe is kind. It isn’t. When the endpoint throws a 429, `shell_exec` gives you precisely zero structured insight. So stop shelling out and use PHP’s cURL so you can read the HTTP status, honor `Retry-After`, back off, and write atomically like a responsible adult.

The existing “Command Output” block will print the message, HTTP status, attempts, and any rate-limit headers. If the server says “Retry-After: 3600,” this will actually wait and retry instead of face-planting immediately. Atomic write avoids serving half a file because someone got twitchy with the refresh button.
